### PR TITLE
Update Apollo client URI and streamline Google OAuth client ID retrieval

### DIFF
--- a/src/context/apollo.tsx
+++ b/src/context/apollo.tsx
@@ -7,7 +7,7 @@ import {
 import React from "react";
 
 const httpLink = createHttpLink({
-  uri: `http://localhost:4000`,
+  uri: `http://localhost:4040`,
 });
 
 interface Props {

--- a/src/context/google-oauth.tsx
+++ b/src/context/google-oauth.tsx
@@ -6,9 +6,8 @@ interface Props {
 }
 
 export function GoogleOAuth({ children }: Props) {
-  const clientId =
-    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID! ||
-    "665602308560-h1o0v8icefcdot57452tk6jiq5488ist.apps.googleusercontent.com";
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
+
   return (
     <GoogleOAuthProvider clientId={clientId}>{children}</GoogleOAuthProvider>
   );


### PR DESCRIPTION
- Changed Apollo client URI from localhost:4000 to localhost:4040 for development.
- Simplified Google OAuth client ID assignment by removing fallback value, ensuring it relies solely on the environment variable.